### PR TITLE
Copy and adjust package files from kriszyp/xstyle

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,0 +1,22 @@
+var miniExcludes = {
+		"dbind/Validator": 1,
+		"dbind/README.md": 1,
+		"dbind/package": 1
+	},
+	isTestRe = /\/tests\//;
+
+var profile = {
+	resourceTags: {
+		test: function(filename, mid){
+			return isTestRe.test(filename) || mid == "dbind/Validator";
+		},
+
+		miniExclude: function(filename, mid){
+			return isTestRe.test(filename) || mid in miniExcludes;
+		},
+
+		amd: function(filename, mid){
+			return /\.js$/.test(filename);
+		}
+	}
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "xstyle",
+  "author": "Kris Zyp",
+  "description": "Functional reactive data binding package that provides straightforward binding of data to components like form inputs, validation connectors, and more.",
+  "licenses": [
+     {
+         "type": "AFLv2.1",
+         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L43"
+     },
+     {
+         "type": "BSD",
+         "url": "http://trac.dojotoolkit.org/browser/dojo/trunk/LICENSE#L13"
+     }
+  ],
+  "repository": {
+    "type":"git",
+    "url":"http://github.com/kriszyp/dbind"
+  },
+  "main": "./bind",
+  "dojoBuild": "package.js"
+}


### PR DESCRIPTION
This is to allow `dojo` to build `dbind` without `json-schema` dependency (as currently `json-schema` is not buildable by `Dojo`).
