### PR TITLE
Support for cleaning up binding, extension, snapshot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ the following methods:
 
 * set(property, value) - Shorthand for get(property).put(value).
 
+Some bindable objects may have shorter lifecycle than others. The following methods can be used to
+make sure bindable object that has finished its lifecycle no longer affects other bindable objects:
+
+* `remove()` - Marks this object as it finished its lifecycle, and cleans up the binding to the
+source object as well as its child bindable objects.
+
+* `reset()` - An internal method, typically called from `to()`, that cleans up the (earlier) binding to
+the source object, as well as the child objects' (earlier) binding to the children of source object
+(if they were bound by the same `to()` call).
+
+* `own(handle, handle, ...)` - An internal method to let `remove()` method call the cleanup method of
+the given handles.
+
+* `resettable(handle, handle, ...)` - An internal method to let `reset()` method call the cleanup
+method of the given handles.
+
 # Composition of Binding-Driven Components
 
 TODO

--- a/README.md
+++ b/README.md
@@ -104,6 +104,35 @@ be updated with error message. This makes it easy to build coherent, manageable
 validated forms. The validation layer is distinct from the UI layer, and they can easily 
 be wired together for responsive validated forms and UIs.
 
+# Extension
+
+An extension is an object that augments a bindable object.
+An extension has `extension` property with `true` value, and can be used by:
+
+```javascript
+bind(something).to({
+	extension: true,
+	optionProperty: 0,
+	is: function(originalIs){ // Change to existing function should have dojo/aspect's around() format
+		// Do something before original is()...
+		originalIs.apply(this, arguments);
+		// Do something after original is()...
+	},
+	customFunction: function(){
+		// Do something...
+	},
+	start: function(){
+		this.customFunction(); // Call customMethod() when extension is applied to a bindable
+	}
+});
+```
+
+Regular properties in extension are mixed into target bindable object.
+Same thing happens for functions that are not in target bindable object, too.
+Functions that pre-exist in target bindable object should have `dojo/aspect`'s `around()` format,
+as the function is augmented in such manner.
+Extension can have `start()` method. If there is, it's called when it's applied to a bindable.
+
 # dbind Interfaces
 
 dbind relies on several interfaces for connecting components. You can interact with these objects

--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ Functions that pre-exist in target bindable object should have `dojo/aspect`'s `
 as the function is augmented in such manner.
 Extension can have `start()` method. If there is, it's called when it's applied to a bindable.
 
+# Snapshot
+
+With `dbind/Snapshot` module, we can let a bindable start keeping its snapshot, by:
+
+```javascript
+require(["dbind/bind", "dbind/Snapshot"], function(bind, Snapshot){
+	bind(something).to(new Snapshot());
+});
+```
+
+A snapshot is another kind of bindable object that keeps the value of upstream source
+(which (for snapshot) is, the bindable object associated with the snapshot)
+of the time snapshot is created. A snapshot won't be updated
+(even if there are changes in value of upstream source) until application requests
+that the snapshot should be in sync with its upstream source, by calling the snapshot's `pull()` method
+(or upstream source's `push()` method).
+
+```javascript
+require(["dbind/bind", "dbind/Snapshot"], function(bind, Snapshot){
+	var binding = bind("Foo").to(new Snapshot()); // A binding is created with a snapshot
+	binding.is("Bar"); // The value is changed to "Bar"
+	binding.pull(); // The value is changed back to "Foo"
+	binding.is("Bar"); // The value is changed again to "Bar"
+	binding.push(); // Save the value
+	binding.is("") // The value becomes an empty string
+	binding.pull(); // The value is changed back to "Bar" (The saved value)
+});
+```
+
+Snapshot will be useful for creating UI with a feature to revert to its earlier data, or checking
+if there is a change in a bindable object since a point in time (by calling its `dirty()` method).
+
 # dbind Interfaces
 
 dbind relies on several interfaces for connecting components. You can interact with these objects

--- a/Snapshot.js
+++ b/Snapshot.js
@@ -1,0 +1,83 @@
+define(["./bind"], function(bind){
+	var Binding = bind.Binding;
+
+	function SnapshotBinding(){
+		Binding.apply(this, arguments);
+	}
+	SnapshotBinding.prototype = new Binding();
+	SnapshotBinding.prototype.get = function(key){
+		this['_' + key] || (this['_' + key] = this.own(new SnapshotBinding().to(this.source && this.source.get(key)))[0]);
+		return Binding.prototype.get.apply(this, arguments);
+	};
+	SnapshotBinding.prototype.put = function(value){
+		this.is(value);
+	};
+	SnapshotBinding.prototype.to = function(source, property){
+		this.reset();
+		source = bind(source);
+		if(property){
+			source = source.get(property);
+		}
+		this.source = source;
+		if(source._ && source._ != this){
+			source._.destroy();
+		}
+		var self = source._ = this;
+		source.getValue(function(value){
+			self.is(value);
+		});
+		return this.enumerate();
+	};
+	SnapshotBinding.prototype.snapshot = function(){};
+	SnapshotBinding.prototype.pull = function(){
+		var self = this;
+		this.source.getValue(function(value){
+			self.is(value);
+		});
+		this.keys(function(i, child){
+			child.pull();
+		});
+	};
+	SnapshotBinding.prototype.push = function(){
+		var self = this;
+		this.getValue(function(value){
+			self.source.put(value);
+		});
+		this.keys(function(i, child){
+			child.push();
+		});
+	};
+
+	function SnapshotExtension(){
+		this.extension = true;
+	}
+	SnapshotExtension.prototype.start = function(){
+		this.snapshot().to(this);
+	};
+	SnapshotExtension.prototype.snapshot = function(){
+		return this._ || this.own(new SnapshotBinding())[0];
+	};
+	SnapshotExtension.prototype.dirty = function(){
+		var dirty,
+			snapshot = this._;
+		if(snapshot){
+			this.getValue(function(value){
+				snapshot.getValue(function(snapValue){
+					snapValue != value && (dirty = true);
+				});
+			});
+			!dirty && this.keys(function(i, child){
+				child.dirty() && (dirty = true);
+			});
+			return dirty;
+		}
+	};
+	SnapshotExtension.prototype.pull = function(){
+		this._ && this._.push();
+	};
+	SnapshotExtension.prototype.push = function(){
+		this._ && this._.pull();
+	};
+
+	return SnapshotExtension;
+});

--- a/bind.js
+++ b/bind.js
@@ -1,9 +1,81 @@
 define([], function(){
+	function on(node, event, callback){
+		var addEventListener = !!node.addEventListener;
+		node[addEventListener ? "addEventListener" : "attachEvent"]((addEventListener ? "" : "on") + event, callback, false);
+		var h = {
+			remove: function(){
+				h && node[addEventListener ? "removeEventListener" : "detachEvent"](event, callback, false);
+				return h = null;
+			}
+		};
+		return h;
+	}
+
+	function around(target, methodName, advice){
+		var original = target[methodName],
+			dispatcher = target[methodName] = function(){
+				if(advice){
+					advice.call(target, original, arguments);
+				}
+			};
+		dispatcher.reconnect = function(to){
+			if(original = to){
+				to.next = dispatcher;
+			}
+		};
+		if(original){
+			original.next = dispatcher;
+		}
+		return {
+			remove: function(){
+				var next = (dispatcher || {}).next;
+				if(next){
+					next.reconnect(original);
+				}else if(target[methodName] == dispatcher && (target[methodName] = original)){
+					original.next = next;
+				}
+				return target = advice = original = dispatcher = null;
+			}
+		};
+	}
+
+	function createOwnFunc(method){
+		function own(){
+			for(var i = 0, l = arguments.length; i < l; ++i){
+				(function(h){
+					var destroyMethodName = typeof h != "object" ? "" :
+						method && (method in h) ? method :
+						"destroyRecursive" in h ? "destroyRecursive" : // For dijit/_WidgetBase
+						"destroy" in h ? "destroy" : // For dijit/Destroyable
+						"remove" in h ? "remove" :
+						"";
+					if(destroyMethodName){
+						var odh = around(this, method || "destroy", function(original, args){
+							h[destroyMethodName]();
+							original.apply(this, args);
+						}), hdh = around(h, destroyMethodName, function(original, args){
+							original.apply(this, args);
+							odh.remove();
+							hdh.remove();
+						});
+					}
+				}).call(this, arguments[i]);
+			}
+			return arguments;
+		}
+		return own;
+	}
+
 	// A basic binding to value, our base class
 	function Binding(value){
 		this.value= value;
 		if(value){
 			value._binding = this;
+			this.own({
+				remove: function(){
+					(value || {})._binding = null;
+				}
+			});
 		}
 	}
 	Binding.prototype = {
@@ -25,6 +97,15 @@ define([], function(){
 					}
 				});
 			}
+			return {
+				remove: function(){
+					for(var i = callbacks.length - 1; i >= 0; --i){
+						if(callbacks[i] == callback){
+							callbacks.splice(i, 1);
+						}
+					}
+				}
+			};
 		},
 		getValue: function(callback){
 			if(this.hasOwnProperty("value")){
@@ -34,9 +115,9 @@ define([], function(){
 		get: function(key, callback){
 			// use an existing child/property if it exists
 			var value, child = this['_' + key] || 
-				(this['_' + key] = this.hasOwnProperty("value") && typeof this.value == "object" ?
+				(this['_' + key] = this.own(this.hasOwnProperty("value") && typeof this.value == "object" ?
 					(value = this.value[key]) && typeof value != "object" ? new PropertyBinding(this.value, key) :
-						convertToBindable(value) : new Binding());
+						convertToBindable(value) : new Binding())[0]);
 			if(callback){
 				return child.receive(callback);
 			}
@@ -47,6 +128,11 @@ define([], function(){
 				this.source.put(value);
 			}
 			value._binding = this;
+			this.own({
+				remove: function(){
+					(value || {})._binding = null;
+				}
+			});
 			this.is(value);
 		},
 		is: function(value){
@@ -76,15 +162,16 @@ define([], function(){
 				}			}
 		},
 		to: function(source, property){
+			this.reset();
 			source = convertToBindable(source);
 			if(property){
 				source = source.get(property);
 			}
 			var self = this;
 			this.source = source;
-			source.receive(function(value){
+			this.resettable(source.receive(function(value){
 				self.is(value);
-			});
+			}));
 			for(var i in this){
 				if(i.charAt(0) == '_'){
 					i = i.slice(1);
@@ -104,30 +191,42 @@ define([], function(){
 				}
 			});
 			return this;
+		},
+		own: createOwnFunc(),
+		resettable: createOwnFunc("reset"),
+		reset: function(){},
+		remove: function(){
+			this.reset();
+			this.destroyed = true;
 		}
 	};
 	// StatefulBinding is used for binding to Stateful objects, particularly Dijit widgets
 	function StatefulBinding(stateful){
 		this.stateful = stateful;
 		stateful._binding = this;
+		this.own({
+			remove: function(){
+				(stateful || {})._binding = null;
+			}
+		});
 	}
 	StatefulBinding.prototype = new Binding({}); 
 	StatefulBinding.prototype.to = function(source){
 		Binding.prototype.to.apply(this, arguments);
 		source = this.source;
 		var stateful = this.stateful;
-		source.receive(function(value){
+		this.resettable(source.receive(function(value){
 			stateful.set('value', value);
-		});
-		stateful.watch('value', function(property, oldValue, value){
+		}));
+		this.resettable(stateful.watch('value', function(property, oldValue, value){
 			if(oldValue !== value){
 				source.put(value);
 			}
-		});
+		}));
 		return this;
 	};
 	StatefulBinding.prototype.get = function(key, callback){
-		return this['_' + key] || (this['_' + key] = new StatefulPropertyBinding(this.stateful, key));
+		return this['_' + key] || (this['_' + key] = this.own(new StatefulPropertyBinding(this.stateful, key))[0]);
 	};
 	StatefulBinding.prototype.keys = function(callback){
 		for(var i in this.stateful){
@@ -140,20 +239,19 @@ define([], function(){
 	function StatefulPropertyBinding(stateful, name){
 		this.stateful = stateful;
 		this.name = name;
+		var self = this;
+		this.own(stateful.watch(name, function(name, old, current){
+			self.value = current;
+			if(old !== current){
+				for(var callback, callbacks = (self.callbacks || []).slice(); callback = callbacks.shift();){
+					callback(current);
+				}
+			}
+		}));
 	}
 	StatefulPropertyBinding.prototype = new Binding;
 	StatefulPropertyBinding.prototype.getValue = function(callback){
-		// get the value of this property
-		var stateful = this.stateful,
-			name = this.name;
-		// get the current value
-		callback(stateful.get(name));
-		// watch for changes
-		stateful.watch(name, function(name, oldValue, newValue){
-			if(oldValue !== newValue){
-				callback(newValue);
-			}
-		});
+		callback(this.stateful.get(this.name));
 	};
 	StatefulPropertyBinding.prototype.is = function(value){
 		// don't go through setters, it is bubbling up through the source
@@ -164,11 +262,26 @@ define([], function(){
 		// put a value, go through setter
 		this.stateful.set(this.name, value);
 	}
+	StatefulPropertyBinding.prototype.to = function(source, property){
+		Binding.prototype.to.call(this, source, property);
+		var source = this.source;
+		this.resettable(this.stateful.watch(this.name, function(name, old, current){
+			if(old !== current){
+				source.put(current);
+			}
+		}));
+		return this;
+	};
 
 	function ElementBinding(element, container){
 		this.element= element;
 		this.container = container;
 		element._binding = this;
+		this.own({
+			remove: function(){
+				(element || {})._binding = null;
+			}
+		});
 	}
 	function ContainerBinding(element){
 		return new ElementBinding(element, true);
@@ -216,8 +329,9 @@ define([], function(){
 			findInputs("input");
 			findInputs("select");
 		}else if(element.tagName in inputLike){
-			var value, binding = this,
-				onchange = element.onchange = function(){
+			var value,
+				binding = this;
+			function onChange(){
 				if(element.type == "radio"){
 					if(element.checked){
 						value = element.value;
@@ -228,26 +342,33 @@ define([], function(){
 					value = element.type == "checkbox" ? element.checked : element.value;
 				}
 				source.put(typeof binding.oldValue == "number" && !isNaN(value) ? +value : value);
-			};
+			}
+			this.resettable(on(element, "change", onChange));
 			if(element.getAttribute('data-continuous')){
-				element.onkeyup = onchange;
+				this.resettable(on(element, "keyup", onChange));
 			}
 		}
 		return this;
 	}
 	ElementBinding.prototype.receive = function(callback){
-		var element = this.element;
+		var h,
+			element = this.element;
 		if(this.container){
 			return Binding.prototype.receive.call(this, callback);
 		}
 		if("value" in element){
 			callback(element.value);
-			element.onchange = function(){
+			h = on(element, "change", function(){
 				callback(element.value);
-			};
+			});
 		}else{
 			callback(element.innerText);
 		}
+		return {
+			remove: function(){
+				h && h.remove();
+			}
+		};
 	};
 	function ArrayBinding(){
 		Binding.apply(this, arguments);
@@ -296,10 +417,10 @@ define([], function(){
 			}
 		},
 		get: function(key){
-			return this[key] || (this[key] = new Binding('None'));
+			return this[key] || (this[key] = this.own(new Binding('None'))[0]);
 		},
 		put: function(value){
-			this.source.put(this.reverseFunc(value));
+			this.source && this.reverseFunc && this.source.put(this.reverseFunc(value));
 		},
 		is: function(){},
 		to: function(source){

--- a/bind.js
+++ b/bind.js
@@ -127,12 +127,14 @@ define([], function(){
 			if(this.source){
 				this.source.put(value);
 			}
-			value._binding = this;
-			this.own({
-				remove: function(){
-					(value || {})._binding = null;
-				}
-			});
+			if(value){
+				value._binding = this;
+				this.own({
+					remove: function(){
+						(value || {})._binding = null;
+					}
+				});
+			}
 			this.is(value);
 		},
 		is: function(value){
@@ -154,7 +156,10 @@ define([], function(){
 		},
 		keys: function(callback){
 			if(this.source){
-				this.source.keys(callback);
+				var self = this;
+				this.source.keys(function(i){
+					callback(i, self.get(i));
+				});
 			}
 			for(var i in this.value){
 				if(i.charAt(0) != '_'){
@@ -172,8 +177,13 @@ define([], function(){
 			this.resettable(source.receive(function(value){
 				self.is(value);
 			}));
+			return this.enumerate();
+		},
+		enumerate: function(){
+			var self = this,
+				source = this.source;
 			for(var i in this){
-				if(i.charAt(0) == '_'){
+				if(/^_.+/.test(i)){
 					i = i.slice(1);
 					var child = self.get(i);
 					var sourceChild = source.get(i);
@@ -328,7 +338,7 @@ define([], function(){
 		Binding.prototype.to.apply(this, arguments);
 		source = this.source;
 		var element = this.element;
-		if(element.tagName == "FORM"){
+		if(this.container || element.tagName == "FORM"){
 			var binding = this;
 			function findInputs(tag){
 				var inputs = element.getElementsByTagName(tag);

--- a/tests/testDijit.js
+++ b/tests/testDijit.js
@@ -13,7 +13,7 @@ define(['dbind/bind', 'dbind/Validator', 'put-selector/put'], function(bind, Val
 
 		function ValidationTextBox(){
 			var mainElement = put('div');
-			var binding = new bind.Container(mainElement);
+			var binding = bind(mainElement, new bind.Container());
 			// the label
 			bind(put(mainElement, 'label')).to(binding, 'title');
 			// the main value is bound to the input

--- a/tests/testForm.js
+++ b/tests/testForm.js
@@ -12,7 +12,7 @@ define(['dbind/bind', 'dbind/Validator', 'put-selector/put'], function(bind, Val
 		
 		function ValidationTextBox(){
 			var mainElement = put('div');
-			var binding = new bind.Container(mainElement);
+			var binding = bind(mainElement, new bind.Container());
 			// the label
 			bind(put(mainElement, 'label')).to(binding.get('title'));
 			// the main value is bound to the input

--- a/tests/testFormBinding.js
+++ b/tests/testFormBinding.js
@@ -12,7 +12,7 @@ define(['dbind/bind', 'dbind/Validator', 'put-selector/put'], function(bind, Val
 		
 		function ValidationTextBox(){
 			var mainElement = put('div');
-			var binding = new bind.Container(mainElement);
+			var binding = bind(mainElement, new bind.Container());
 			// the label
 			bind(put(mainElement, 'label')).to(binding.get('title'));
 			// the main value is bound to the input

--- a/tests/testSnapshot.html
+++ b/tests/testSnapshot.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Test snapshot</title>
+		<style type="text/css">
+			@import "../../dojo/resources/dojo.css";
+			.container {
+				padding: 8px;
+			}
+			.caption {
+				display: inline-block;
+				width: 8ex;
+			}
+		</style>
+		<script type="text/javascript" src="../../dojo/dojo.js" 
+			data-dojo-config="async: 1"></script>
+		<script type="text/javascript">
+			require([
+				"dbind/bind",
+				"dbind/Snapshot",
+				"dojo/on",
+				"dojo/domReady!"
+			], function(bind, Snapshot, on){
+				var data = {
+					Group: "Engineer",
+					First: "Anne",
+					Last: "Ackerman",
+					Location: "NY",
+					Office: "1S76",
+					Email: "a.a@test.com",
+					Tel: "123-764-8237",
+					Fax: "123-764-8228"
+				};
+				bind(document.getElementById("mastergroup")).to(new bind.Container()).to(bind(data, new Snapshot()));
+				bind(document.getElementById("commitresetgroup")).to(new bind.Container()).to(bind(data));
+				bind(document.getElementById("savecancelgroup")).to(new bind.Container()).to(bind(data).snapshot());
+				on(document.getElementById("commit"), "click", function(){
+					bind(data).push();
+				});
+				on(document.getElementById("reset"), "click", function(){
+					bind(data).pull();
+				});
+				on(document.getElementById("save"), "click", function(){
+					bind(data).pull();
+				});
+				on(document.getElementById("cancel"), "click", function(){
+					bind(data).push();
+				});
+			});
+		</script>
+	</head>
+	<body>
+		<h1 class="container">Snapshot test (commit, reset, save, cancel)</h1>
+		<div class="container" id="mastergroup">
+			<h3>(Master data)</h3>
+			<div><span class="caption">Group:</span> <input type="text" name="Group" disabled></div>
+			<div><span class="caption">First:</span> <input type="text" name="First" disabled></div>
+			<div><span class="caption">Last:</span> <input type="text" name="Last" disabled></div>
+			<div><span class="caption">Location:</span> <input type="text" name="Location" disabled></div>
+			<div><span class="caption">Office:</span> <input type="text" name="Office" disabled></div>
+			<div><span class="caption">Email:</span> <input type="text" name="Email" disabled></div>
+			<div><span class="caption">Tel:</span> <input type="text" name="Tel" disabled></div>
+			<div><span class="caption">Fax:</span> <input type="text" name="Fax" disabled></div>
+		</div>
+		<div class="container" id="commitresetgroup">
+			<div><span class="caption">Group:</span> <input type="text" name="Group"></div>
+			<div><span class="caption">First:</span> <input type="text" name="First"></div>
+			<div><span class="caption">Last:</span> <input type="text" name="Last"></div>
+			<div><span class="caption">Location:</span> <input type="text" name="Location"></div>
+			<div><span class="caption">Office:</span> <input type="text" name="Office"></div>
+			<div><span class="caption">Email:</span> <input type="text" name="Email"></div>
+			<div><span class="caption">Tel:</span> <input type="text" name="Tel"></div>
+			<div><span class="caption">Fax:</span> <input type="text" name="Fax"></div>
+			<div>
+				<input id="commit" type="button" value="Commit">
+				<input id="reset" type="button" value="Reset">
+			</div>
+		</div>
+		<div class="container" id="savecancelgroup">
+			<div><span class="caption">Group:</span> <input type="text" name="Group"></div>
+			<div><span class="caption">First:</span> <input type="text" name="First"></div>
+			<div><span class="caption">Last:</span> <input type="text" name="Last"></div>
+			<div><span class="caption">Location:</span> <input type="text" name="Location"></div>
+			<div><span class="caption">Office:</span> <input type="text" name="Office"></div>
+			<div><span class="caption">Email:</span> <input type="text" name="Email"></div>
+			<div><span class="caption">Tel:</span> <input type="text" name="Tel"></div>
+			<div><span class="caption">Fax:</span> <input type="text" name="Fax"></div>
+			<div>
+				<input id="save" type="button" value="Save">
+				<input id="cancel" type="button" value="Cancel">
+			</div>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
# Cleaning up binding

Some bindable objects may have shorter lifecycle than others. Implemented the following external/APIs to make sure bindable object that has finished its lifecycle no longer affects other bindable objects:
- `remove()` - Marks this object as it finished its lifecycle, and cleans up the binding to the source object as well as its child bindable objects.
- `reset()` - An internal method, typically called from `to()`, that cleans up the (earlier) binding to the source object, as well as the child objects' (earlier) binding to the children of source object (if they were bound by the same `to()` call).
- `own(handle, handle, ...)` - An internal method to let `remove()` method call the cleanup method of the given handles.
- `resettable(handle, handle, ...)` - An internal method to let `reset()` method call the cleanup method of the given handles.
# Extension

An extension is an object that augments a bindable object. An extension has `extension` property with `true` value, and can be used by:

``` javascript
bind(something).to({
    extension: true,
    optionProperty: 0,
    is: function(originalIs){ // Change to existing function should have dojo/aspect's around() format
        // Do something before original is()...
        originalIs.apply(this, arguments);
        // Do something after original is()...
    },
    customFunction: function(){
        // Do something...
    },
    start: function(){
        this.customFunction(); // Call customMethod() when extension is applied to a bindable
    }
});
```

Regular properties in extension are mixed into target bindable object. Same thing happens for functions that are not in target bindable object, too. Functions that pre-exist in target bindable object should have `dojo/aspect`'s `around()` format, as the function is augmented in such manner. Extension can have `start()` method. If there is, it's called when it's applied to a bindable.

@kriszyp Wondering if this spec aligns to what you had in mind, or you thought of something different.
# Snapshot

With `dbind/Snapshot` module, we can let a bindable start keeping its snapshot, by:

``` javascript
require(["dbind/bind", "dbind/Snapshot"], function(bind, Snapshot){
    bind(something).to(new Snapshot());
});
```

A snapshot is another kind of bindable object that keeps the value of upstream source (which (for snapshot) is, the bindable object associated with the snapshot) of the time snapshot is created. A snapshot won't be updated
(even if there are changes in value of upstream source) until application requests that the snapshot should be in sync with its upstream source, by calling the snapshot's `pull()` method (or upstream source's `push()` method).

``` javascript
require(["dbind/bind", "dbind/Snapshot"], function(bind, Snapshot){
    var binding = bind("Foo").to(new Snapshot()); // A binding is created with a snapshot
    binding.is("Bar"); // The value is changed to "Bar"
    binding.pull(); // The value is changed back to "Foo"
    binding.is("Bar"); // The value is changed again to "Bar"
    binding.push(); // Save the value
    binding.is("") // The value becomes an empty string
    binding.pull(); // The value is changed back to "Bar" (The saved value)
});
```

Snapshot will be useful for creating UI with a feature to revert to its earlier data, or checking if there is a change in a bindable object since a point in time (by calling its `dirty()` method).
