### PR TITLE
Support for repeat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ the following methods:
 
 * set(property, value) - Shorthand for get(property).put(value).
 
+Some bindable objects may have shorter lifecycle than others. The following methods can be used to
+make sure bindable object that has finished its lifecycle no longer affects other bindable objects:
+
+* `remove()` - Marks this object as it finished its lifecycle, and cleans up the binding to the
+source object as well as its child bindable objects.
+
+* `reset()` - An internal method, typically called from `to()`, that cleans up the (earlier) binding to
+the source object, as well as the child objects' (earlier) binding to the children of source object
+(if they were bound by the same `to()` call).
+
+* `own(handle, handle, ...)` - An internal method to let `remove()` method call the cleanup method of
+the given handles.
+
+* `resettable(handle, handle, ...)` - An internal method to let `reset()` method call the cleanup
+method of the given handles.
+
 # Composition of Binding-Driven Components
 
 TODO

--- a/README.md
+++ b/README.md
@@ -104,6 +104,27 @@ be updated with error message. This makes it easy to build coherent, manageable
 validated forms. The validation layer is distinct from the UI layer, and they can easily 
 be wired together for responsive validated forms and UIs.
 
+# Repeating UI
+
+By importing `dbind/forEach` module (which returns the same object as `dbind/bind`),
+you can create repeating UI from array:
+
+```javascript
+require(['dbind/forEach'], function(bind){
+	var a = ['foo', 'bar'];
+	bind(anElement).forEach(a, {
+		createChild: function(entry){
+			var element = document.createElement("div");
+			element.innerText = entry;
+			return element;
+		}
+	});
+});
+```
+
+If the array implements `observe(function(idx, removals, adds){ ... })` interface upon removals/adds of array
+elements (splice), the UI created in above way responds to such removals/adds.
+
 # dbind Interfaces
 
 dbind relies on several interfaces for connecting components. You can interact with these objects

--- a/bind.js
+++ b/bind.js
@@ -1,9 +1,81 @@
 define([], function(){
+	function on(node, event, callback){
+		var addEventListener = !!node.addEventListener;
+		node[addEventListener ? "addEventListener" : "attachEvent"]((addEventListener ? "" : "on") + event, callback, false);
+		var h = {
+			remove: function(){
+				h && node[addEventListener ? "removeEventListener" : "detachEvent"](event, callback, false);
+				return h = null;
+			}
+		};
+		return h;
+	}
+
+	function around(target, methodName, advice){
+		var original = target[methodName],
+			dispatcher = target[methodName] = function(){
+				if(advice){
+					advice.call(target, original, arguments);
+				}
+			};
+		dispatcher.reconnect = function(to){
+			if(original = to){
+				to.next = dispatcher;
+			}
+		};
+		if(original){
+			original.next = dispatcher;
+		}
+		return {
+			remove: function(){
+				var next = (dispatcher || {}).next;
+				if(next){
+					next.reconnect(original);
+				}else if(target[methodName] == dispatcher && (target[methodName] = original)){
+					original.next = next;
+				}
+				return target = advice = original = dispatcher = null;
+			}
+		};
+	}
+
+	function createOwnFunc(method){
+		function own(){
+			for(var i = 0, l = arguments.length; i < l; ++i){
+				(function(h){
+					var destroyMethodName = typeof h != "object" ? "" :
+						method && (method in h) ? method :
+						"destroyRecursive" in h ? "destroyRecursive" : // For dijit/_WidgetBase
+						"destroy" in h ? "destroy" : // For dijit/Destroyable
+						"remove" in h ? "remove" :
+						"";
+					if(destroyMethodName){
+						var odh = around(this, method || "destroy", function(original, args){
+							h[destroyMethodName]();
+							original.apply(this, args);
+						}), hdh = around(h, destroyMethodName, function(original, args){
+							original.apply(this, args);
+							odh.remove();
+							hdh.remove();
+						});
+					}
+				}).call(this, arguments[i]);
+			}
+			return arguments;
+		}
+		return own;
+	}
+
 	// A basic binding to value, our base class
 	function Binding(value){
 		this.value= value;
 		if(value){
 			value._binding = this;
+			this.own({
+				remove: function(){
+					(value || {})._binding = null;
+				}
+			});
 		}
 	}
 	Binding.prototype = {
@@ -25,6 +97,15 @@ define([], function(){
 					}
 				});
 			}
+			return {
+				remove: function(){
+					for(var i = callbacks.length - 1; i >= 0; --i){
+						if(callbacks[i] == callback){
+							callbacks.splice(i, 1);
+						}
+					}
+				}
+			};
 		},
 		getValue: function(callback){
 			if(this.hasOwnProperty("value")){
@@ -34,9 +115,9 @@ define([], function(){
 		get: function(key, callback){
 			// use an existing child/property if it exists
 			var value, child = this['_' + key] || 
-				(this['_' + key] = this.hasOwnProperty("value") && typeof this.value == "object" ?
+				(this['_' + key] = this.own(this.hasOwnProperty("value") && typeof this.value == "object" ?
 					(value = this.value[key]) && typeof value != "object" ? new PropertyBinding(this.value, key) :
-						convertToBindable(value) : new Binding());
+						convertToBindable(value) : new Binding())[0]);
 			if(callback){
 				return child.receive(callback);
 			}
@@ -47,6 +128,11 @@ define([], function(){
 				this.source.put(value);
 			}
 			value._binding = this;
+			this.own({
+				remove: function(){
+					(value || {})._binding = null;
+				}
+			});
 			this.is(value);
 		},
 		is: function(value){
@@ -76,15 +162,16 @@ define([], function(){
 				}			}
 		},
 		to: function(source, property){
+			this.reset();
 			source = convertToBindable(source);
 			if(property){
 				source = source.get(property);
 			}
 			var self = this;
 			this.source = source;
-			source.receive(function(value){
+			this.resettable(source.receive(function(value){
 				self.is(value);
-			});
+			}));
 			for(var i in this){
 				if(i.charAt(0) == '_'){
 					i = i.slice(1);
@@ -104,30 +191,42 @@ define([], function(){
 				}
 			});
 			return this;
+		},
+		own: createOwnFunc(),
+		resettable: createOwnFunc("reset"),
+		reset: function(){},
+		remove: function(){
+			this.reset();
+			this.destroyed = true;
 		}
 	};
 	// StatefulBinding is used for binding to Stateful objects, particularly Dijit widgets
 	function StatefulBinding(stateful){
 		this.stateful = stateful;
 		stateful._binding = this;
+		this.own({
+			remove: function(){
+				(stateful || {})._binding = null;
+			}
+		});
 	}
 	StatefulBinding.prototype = new Binding({}); 
 	StatefulBinding.prototype.to = function(source){
 		Binding.prototype.to.apply(this, arguments);
 		source = this.source;
 		var stateful = this.stateful;
-		source.receive(function(value){
+		this.resettable(source.receive(function(value){
 			stateful.set('value', value);
-		});
-		stateful.watch('value', function(property, oldValue, value){
+		}));
+		this.resettable(stateful.watch('value', function(property, oldValue, value){
 			if(oldValue !== value){
 				source.put(value);
 			}
-		});
+		}));
 		return this;
 	};
 	StatefulBinding.prototype.get = function(key, callback){
-		return this['_' + key] || (this['_' + key] = new StatefulPropertyBinding(this.stateful, key));
+		return this['_' + key] || (this['_' + key] = this.own(new StatefulPropertyBinding(this.stateful, key))[0]);
 	};
 	StatefulBinding.prototype.keys = function(callback){
 		for(var i in this.stateful){
@@ -140,20 +239,19 @@ define([], function(){
 	function StatefulPropertyBinding(stateful, name){
 		this.stateful = stateful;
 		this.name = name;
+		var self = this;
+		this.own(stateful.watch(name, function(name, old, current){
+			self.value = current;
+			if(old !== current){
+				for(var callback, callbacks = (self.callbacks || []).slice(); callback = callbacks.shift();){
+					callback(current);
+				}
+			}
+		}));
 	}
 	StatefulPropertyBinding.prototype = new Binding;
 	StatefulPropertyBinding.prototype.getValue = function(callback){
-		// get the value of this property
-		var stateful = this.stateful,
-			name = this.name;
-		// get the current value
-		callback(stateful.get(name));
-		// watch for changes
-		stateful.watch(name, function(name, oldValue, newValue){
-			if(oldValue !== newValue){
-				callback(newValue);
-			}
-		});
+		callback(this.stateful.get(this.name));
 	};
 	StatefulPropertyBinding.prototype.is = function(value){
 		// don't go through setters, it is bubbling up through the source
@@ -164,11 +262,26 @@ define([], function(){
 		// put a value, go through setter
 		this.stateful.set(this.name, value);
 	}
+	StatefulPropertyBinding.prototype.to = function(source, property){
+		Binding.prototype.to.call(this, source, property);
+		var source = this.source;
+		this.resettable(this.stateful.watch(this.name, function(name, old, current){
+			if(old !== current){
+				source.put(current);
+			}
+		}));
+		return this;
+	};
 
 	function ElementBinding(element, container){
 		this.element= element;
 		this.container = container;
 		element._binding = this;
+		this.own({
+			remove: function(){
+				(element || {})._binding = null;
+			}
+		});
 	}
 	function ContainerBinding(element){
 		return new ElementBinding(element, true);
@@ -216,8 +329,9 @@ define([], function(){
 			findInputs("input");
 			findInputs("select");
 		}else if(element.tagName in inputLike){
-			var value, binding = this,
-				onchange = element.onchange = function(){
+			var value,
+				binding = this;
+			function onChange(){
 				if(element.type == "radio"){
 					if(element.checked){
 						value = element.value;
@@ -228,26 +342,33 @@ define([], function(){
 					value = element.type == "checkbox" ? element.checked : element.value;
 				}
 				source.put(typeof binding.oldValue == "number" && !isNaN(value) ? +value : value);
-			};
+			}
+			this.resettable(on(element, "change", onChange));
 			if(element.getAttribute('data-continuous')){
-				element.onkeyup = onchange;
+				this.resettable(on(element, "keyup", onChange));
 			}
 		}
 		return this;
 	}
 	ElementBinding.prototype.receive = function(callback){
-		var element = this.element;
+		var h,
+			element = this.element;
 		if(this.container){
 			return Binding.prototype.receive.call(this, callback);
 		}
 		if("value" in element){
 			callback(element.value);
-			element.onchange = function(){
+			h = on(element, "change", function(){
 				callback(element.value);
-			};
+			});
 		}else{
 			callback(element.innerText);
 		}
+		return {
+			remove: function(){
+				h && h.remove();
+			}
+		};
 	};
 	function ArrayBinding(){
 		Binding.apply(this, arguments);
@@ -296,10 +417,10 @@ define([], function(){
 			}
 		},
 		get: function(key){
-			return this[key] || (this[key] = new Binding('None'));
+			return this[key] || (this[key] = this.own(new Binding('None'))[0]);
 		},
 		put: function(value){
-			this.source.put(this.reverseFunc(value));
+			this.source && this.reverseFunc && this.source.put(this.reverseFunc(value));
 		},
 		is: function(){},
 		to: function(source){

--- a/bind.js
+++ b/bind.js
@@ -316,13 +316,12 @@ define([], function(){
 		source = this.source;
 		var element = this.element;
 		if(element.tagName == "FORM"){
-			var binding = this;
 			function findInputs(tag){
 				var inputs = element.getElementsByTagName(tag);
 				for(var i = 0; i < inputs.length; i++){
 					var input = inputs[i];
 					if(input.name){
-						bind(input, binding.get(input.name));
+						bind(input, source.get(input.name));
 					}
 				}
 			}
@@ -489,8 +488,18 @@ define([], function(){
 				return new PropertyBinding(object, key);
 			}
 		}
-	};
+	}
+	function remove(element){
+		for(var list = [element].concat([].slice.call(element.getElementsByTagName("*"), 0)), i = 0, l = list.length; i < l; ++i){
+			if(list[i]._binding){
+				list[i]._binding.remove();
+			}
+		}
+	}
+
 	bind.get = get;
+	bind.createOwnFunc = createOwnFunc;
+	bind.remove = remove;
 	bind.Element = ElementBinding;
 	bind.Container = ContainerBinding;
 	bind.Binding = Binding;

--- a/forEach.js
+++ b/forEach.js
@@ -1,0 +1,113 @@
+define(["./bind"], function(bind){
+	var undef,
+		childrenStandard,
+		tmpDiv,
+		tmpDoc,
+		resettableForEach = bind.createOwnFunc("resetForEach"),
+		ElementBinding = bind.Element;
+
+	function when(value, callback){
+		if(value && value.then){
+			return value.then(callback);
+		}
+		return callback(value);
+	}
+
+	function isArray(it){
+		return typeof it == "object" && it.splice;
+	}
+	isArray = Array.isArray || isArray;
+
+	function createOption(entry){
+		var doc = (this.object.ownerDocument || document),
+			option = doc.createElement("option");
+		bind(option).to(entry);
+		return option;
+	}
+
+	function childElement(element, idx){
+		if(childrenStandard === undef){
+			var div = tmpDiv || document.createElement("div");
+			tmpDoc = tmpDoc || document;
+			div.innerHTML = "<a>a</a><!-- Hoge -->";
+			childrenStandard = div.children.length == 1;
+		}
+		if(childrenStandard){
+			return element.children[idx];
+		}
+		var ref = element.firstChild;
+		for(; ref && idx > 0; ref = ref.nextSibling){
+			if(ref.nodeType == 1){ --idx; }
+		}
+		return ref;
+	}
+
+	function removeNode(node){
+		if(!tmpDiv || tmpDoc != node.ownerDocument){
+			tmpDiv = (tmpDoc = node.ownerDocument).createElement("div");
+		}
+		tmpDiv.appendChild(node.parentNode ? node.parentNode.removeChild(node) : node);
+		tmpDiv.innerHTML = "";
+	}
+
+	function forEach(collection, options){
+		var self = this,
+			binding = this.isSnapshot ? this.source : this,
+			element = (binding.stateful || {}).containerNode || (binding.stateful || {}).domNode || binding.element,
+			createChild = options.createChild || element.tagName == "SELECT" && createOption,
+			insertedChild = options.insertedChild,
+			removeChild = options.removeChild || bind.remove,
+			parent = options.parent;
+
+		function observe(idx, removals, adds){
+			var i,
+				l,
+				next,
+				child = childElement(element, idx);
+			for(i = 0, l = removals.length; i < l; ++i){
+				if(child){
+					for(next = child.nextSibling; next && next.nodeType != 1; next = next.nextSibling);
+					removeChild.call(self, child);
+					removeNode(child);
+					child = next;
+				}
+				// Though we may create a new binding for added entries, entries being removed from collection may be referred by other correction.
+				// Therefore we cannot remove binding for removed entries.
+				// It's application's responsibility to remove binding for collections entries as needed.
+			}
+			for(i = 0, l = adds.length; i < l; ++i){
+				if(parent){
+					bind(adds[i]).parent = parent;
+				}
+				var created = createChild.call(self, adds[i]);
+				element.insertBefore(created, child || null);
+				if(insertedChild){
+					insertedChild.call(self, created);
+				}
+			}
+			if(element.tagName == "SELECT"){
+				var container = bind(element);
+				container.getValue(function(value){
+					// Re-apply the value in case there was not a match in older collection but there was in newer collection
+					container.setValue("");
+					container.setValue(value);
+				});
+			}
+		}
+
+		this.resetForEach();
+		when(collection, function(a){
+			observe(0, isArray(this.forEach) ? this.forEach : [], a);
+			this.forEach = a;
+		});
+		(collection || {}).observe && resettableForEach.call(this, collection.observe(observe, true, true));
+		return this;
+	}
+
+	var SnapshotBindingProto = (bind.Snapshot || {}).prototype || {};
+	ElementBinding.prototype.forEach = SnapshotBindingProto.forEach = forEach;
+	ElementBinding.prototype.resetForEach = function(){};
+	SnapshotBindingProto.resetForEach = function(){};
+
+	return bind;
+});

--- a/store/Observable.js
+++ b/store/Observable.js
@@ -1,0 +1,202 @@
+define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/Deferred", "dojo/_base/array" /*=====, "dojo/store/api/Store" =====*/
+], function(kernel, lang, Deferred, array /*=====, Store =====*/){
+
+// module:
+//		dojo/store/Observable
+
+var Observable = function(/*Store*/ store){
+	// summary:
+	//		The Observable store wrapper takes a store and sets an observe method on query()
+	//		results that can be used to monitor results for changes.
+	//
+	// description:
+	//		Observable wraps an existing store so that notifications can be made when a query
+	//		is performed.
+	//
+	// example:
+	//		Create a Memory store that returns an observable query, and then log some
+	//		information about that query.
+	//
+	//	|	var store = Observable(new Memory({
+	//	|		data: [
+	//	|			{id: 1, name: "one", prime: false},
+	//	|			{id: 2, name: "two", even: true, prime: true},
+	//	|			{id: 3, name: "three", prime: true},
+	//	|			{id: 4, name: "four", even: true, prime: false},
+	//	|			{id: 5, name: "five", prime: true}
+	//	|		]
+	//	|	}));
+	//	|	var changes = [], results = store.query({ prime: true });
+	//	|	var observer = results.observe(function(object, previousIndex, newIndex){
+	//	|		changes.push({previousIndex:previousIndex, newIndex:newIndex, object:object});
+	//	|	});
+	//
+	//		See the Observable tests for more information.
+
+	var undef, queryUpdaters = [], revision = 0;
+	// a Comet driven store could directly call notify to notify observers when data has
+	// changed on the backend
+	// create a new instance
+	store = lang.delegate(store);
+	
+	store.notify = function(object, existingId){
+		revision++;
+		var updaters = queryUpdaters.slice();
+		for(var i = 0, l = updaters.length; i < l; i++){
+			updaters[i](object, existingId);
+		}
+	};
+	var originalQuery = store.query;
+	store.query = function(query, options){
+		options = options || {};
+		var results = originalQuery.apply(this, arguments);
+		if(results && results.forEach){
+			var nonPagedOptions = lang.mixin({}, options);
+			delete nonPagedOptions.start;
+			delete nonPagedOptions.count;
+
+			var queryExecutor = store.queryEngine && store.queryEngine(query, nonPagedOptions);
+			var queryRevision = revision;
+			var listeners = [], listenerOptions = [], queryUpdater;
+			results.observe = function(listener, includeObjectUpdates, spliceStyle){
+				listenerOptions.push({
+					includeObjectUpdates: includeObjectUpdates,
+					spliceStyle: spliceStyle
+				});
+				if(listeners.push(listener) == 1){
+					// first listener was added, create the query checker and updater
+					queryUpdaters.push(queryUpdater = function(changed, existingId){
+						Deferred.when(results, function(resultsArray){
+							var atEnd = resultsArray.length != options.count;
+							var i, l, listener;
+							if(++queryRevision != revision){
+								throw new Error("Query is out of date, you must observe() the query prior to any data modifications");
+							}
+							var removedObject, removedFrom = -1, insertedInto = -1;
+							if(existingId !== undef){
+								// remove the old one
+								for(i = 0, l = resultsArray.length; i < l; i++){
+									var object = resultsArray[i];
+									if(store.getIdentity(object) == existingId){
+										removedObject = object;
+										removedFrom = i;
+										if(queryExecutor || !changed){// if it was changed and we don't have a queryExecutor, we shouldn't remove it because updated objects would be eliminated
+											resultsArray.splice(i, 1);
+										}
+										break;
+									}
+								}
+							}
+							if(queryExecutor){
+								// add the new one
+								if(changed &&
+										// if a matches function exists, use that (probably more efficient)
+										(queryExecutor.matches ? queryExecutor.matches(changed) : queryExecutor([changed]).length)){
+
+									var firstInsertedInto = removedFrom > -1 ? 
+										removedFrom : // put back in the original slot so it doesn't move unless it needs to (relying on a stable sort below)
+										resultsArray.length;
+									resultsArray.splice(firstInsertedInto, 0, changed); // add the new item
+									insertedInto = array.indexOf(queryExecutor(resultsArray), changed); // sort it
+									// we now need to push the chagne back into the original results array
+									resultsArray.splice(firstInsertedInto, 1); // remove the inserted item from the previous index
+									
+									if((options.start && insertedInto == 0) ||
+										(!atEnd && insertedInto == resultsArray.length)){
+										// if it is at the end of the page, assume it goes into the prev or next page
+										insertedInto = -1;
+									}else{
+										resultsArray.splice(insertedInto, 0, changed); // and insert into the results array with the correct index
+									}
+								}
+							}else if(changed){
+								// we don't have a queryEngine, so we can't provide any information
+								// about where it was inserted or moved to. If it is an update, we leave it's position alone, other we at least indicate a new object
+								if(existingId !== undef){
+									// an update, keep the index the same
+									insertedInto = removedFrom;
+								}else if(!options.start){
+									// a new object
+									insertedInto = store.defaultIndex || 0;
+									resultsArray.splice(insertedInto, 0, changed);
+								}
+							}
+							if(removedFrom > -1 || insertedInto > -1){
+								var copyListeners = listeners.slice(),
+									copyOptions = listenerOptions.slice();
+								for(i = 0;listener = copyListeners[i]; i++){
+									var listenerOption = copyOptions[i];
+									if(listenerOption.includeObjectUpdates || !queryExecutor || removedFrom != insertedInto){
+										if(!listenerOption.spliceStyle){
+											listener(changed || removedObject, removedFrom, insertedInto);
+										}else if(removedFrom == insertedInto){
+											listener(removedFrom, [removedObject], [changed]);
+										}else{
+											removedFrom > -1 && listener(removedFrom, [removedObject], []);
+											insertedInto > -1 && listener(insertedInto, [], [changed]);
+										}
+									}
+								}
+							}
+						});
+					});
+				}
+				var handle = {};
+				// TODO: Remove cancel in 2.0.
+				handle.remove = handle.cancel = function(){
+					// remove this listener
+					var index = array.indexOf(listeners, listener);
+					if(index > -1){ // check to make sure we haven't already called cancel
+						listenerOptions.splice(index, 1);
+						listeners.splice(index, 1);
+						if(!listeners.length){
+							// no more listeners, remove the query updater too
+							queryUpdaters.splice(array.indexOf(queryUpdaters, queryUpdater), 1);
+						}
+					}
+				};
+				return handle;
+			};
+		}
+		return results;
+	};
+	var inMethod;
+	function whenFinished(method, action){
+		var original = store[method];
+		if(original){
+			store[method] = function(value){
+				if(inMethod){
+					// if one method calls another (like add() calling put()) we don't want two events
+					return original.apply(this, arguments);
+				}
+				inMethod = true;
+				try{
+					var results = original.apply(this, arguments);
+					Deferred.when(results, function(results){
+						action((typeof results == "object" && results) || value);
+					});
+					return results;
+				}finally{
+					inMethod = false;
+				}
+			};
+		}
+	}
+	// monitor for updates by listening to these methods
+	whenFinished("put", function(object){
+		store.notify(object, store.getIdentity(object));
+	});
+	whenFinished("add", function(object){
+		store.notify(object);
+	});
+	whenFinished("remove", function(id){
+		store.notify(undefined, id);
+	});
+
+	return store;
+};
+
+lang.setObject("dojo.store.Observable", Observable);
+
+return Observable;
+});

--- a/tests/testForEach.html
+++ b/tests/testForEach.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Test forEach</title>
+		<style type="text/css">
+			@import "../../dojo/resources/dojo.css";
+		</style>
+		<script type="text/javascript" src="../../dojo/dojo.js" 
+			data-dojo-config="async: 1"></script>
+		<script type="text/javascript">
+			require([
+				"dbind/tests/testRepeatViewModel",
+				"dbind/forEach",
+				"dojo/on",
+				"dojo/domReady!"
+			], function(viewModel, bind, on){
+				bind(document.getElementById("container")).forEach(viewModel.collection, {
+					createChild: function(entry){
+						var div = document.createElement("div"),
+							form = document.createElement("form"),
+							checkbox = document.createElement("input"),
+							textbox = document.createElement("input"),
+							button = document.createElement("input");
+						checkbox.setAttribute("name", "finished");
+						checkbox.setAttribute("type", "checkbox");
+						textbox.setAttribute("name", "title");
+						textbox.setAttribute("type", "text");
+						button.setAttribute("type", "button");
+						button.setAttribute("value", "Remove");
+						on(button, "click", function(event){
+							viewModel.removeEntry.call(this, event, bind(event.target), bind(entry));
+						});
+						form.appendChild(checkbox);
+						form.appendChild(textbox);
+						form.appendChild(button);
+						div.appendChild(form);
+						bind(form).to(entry);
+						return div;
+					},
+					parent: viewModel
+				});
+				var form = document.getElementById("bottomarea");
+				bind(form).to(viewModel);
+				on(form.addButton, "click", function(event){
+					viewModel.addEntry.call(this, event, bind(event.target), viewModel);
+				});
+				bind(form.activeButton, "filterMode").to("active");
+				bind(form.finishedButton, "filterMode").to("finished");
+				for(var a = [form.allButton, form.activeButton, form.finishedButton], i = 0, l = a.length; i < l; ++i){
+					on(a[i], "click", function(event){
+						viewModel.filter.call(this, event, bind(event.target), viewModel);
+					});
+				}
+			});
+		</script>
+	</head>
+	<body class="claro">
+		<h2>Test forEach</h2>
+		<div id="container"></div>
+		<form id="bottomarea">
+			<div>
+				<input name="textToAdd" type="text">
+				<input name="addButton" type="button">
+			</div>
+			<div>
+				<input name="allButton" type="button">
+				<input name="activeButton" type="button">
+				<input name="finishedButton" type="button">
+			</div>
+		</form>
+	</body>
+</html>

--- a/tests/testRepeatViewModel.js
+++ b/tests/testRepeatViewModel.js
@@ -1,0 +1,147 @@
+define([
+	"../bind",
+	"../store/Observable",
+	"dojo/_base/array",
+	"dojo/_base/lang",
+	"dojo/when",
+	"dojo/store/Memory",
+	"dojo/promise/all"
+], function(bind, Observable, array, lang, when, Memory, all){
+	var collection = Observable(new Memory({data: [
+			{id: 0, title: "Wash my car", finished: false},
+			{id: 1, title: "Walk my dog", finished: true}
+		]})),
+		results = collection.query({}),
+		unfiltered = collection.query({filtered: {test: function(value){ return !value; }}}),
+		active = collection.query({finished: {test: function(value){ return !value; }}}),
+		finished = collection.query({finished: {test: function(value){ return value; }}}),
+		count = bind(0),
+		unfilteredCount = bind(0),
+		activeCount = bind(0),
+		finishedCount = bind(0),
+		filterMode = bind(""),
+		currentFilterMode = "";
+
+	results.observe(function(idx, removals, adds){
+		when(results, function(results){
+			count.is(results.length);
+		});
+		array.forEach(removals, function(removal){
+			bind(removal).remove();
+		});
+		array.forEach(adds, function(add){
+			var filtered = add.finished && currentFilterMode == "active" || !add.finished && currentFilterMode == "finished";
+			if(add.filtered ^ filtered){
+				collection.put(lang.mixin(add, {filtered: filtered}));
+			}
+			var lastFinished;
+			bind(add).get("finished", function(finished){
+				if(lastFinished ^ finished){
+					collection.put(lang.delegate(add, {finished: lastFinished = finished, filtered: finished && currentFilterMode == "active" || !finished && currentFilterMode == "finished"})); // To avoid race-condition finished state is sent to the entry vs. this callback
+				}
+			});
+		});
+	}, false, true);
+
+	unfiltered.observe(function(){
+		when(unfiltered, function(unfiltered){
+			unfilteredCount.is(unfiltered.length);
+		});
+	});
+
+	active.observe(function(){
+		when(active, function(active){
+			activeCount.is(active.length);
+		});
+	}, false, true);
+
+	finished.observe(function(){
+		when(finished, function(finished){
+			finishedCount.is(finished.length);
+		});
+	}, false, true);
+
+	when(results, function(a){
+		count.is(a.length);
+		array.forEach(a, function(entry){
+			var lastFinished;
+			bind(entry).get("finished", function(finished){
+				if(lastFinished ^ finished){
+					collection.put(lang.delegate(entry, {finished: lastFinished = finished, filtered: finished && currentFilterMode == "active" || !finished && currentFilterMode == "finished"})); // To avoid race-condition finished state is sent to the entry vs. this callback
+				}
+			});
+		});
+	});
+
+	when(active, function(a){
+		activeCount.is(a.length);
+	});
+
+	when(finished, function(a){
+		finishedCount.is(a.length);
+	});
+
+	filterMode.receive(function(mode){
+		if(currentFilterMode != mode){
+			currentFilterMode = mode;
+			when(all([active, finished]), function(pair){
+				array.forEach(pair[0], function(entry){
+					collection.put(lang.mixin(entry, {filtered: mode == "finished"}));
+				});
+				array.forEach(pair[1], function(entry){
+					collection.put(lang.mixin(entry, {filtered: mode == "active"}));
+				});
+			});
+		}
+	});
+
+	var viewModel = lang.mixin(bind({
+		textToAdd: "",
+		addButton: "Add"
+	}), {
+		_count: count,
+		_activeCount: activeCount,
+		_finishedCount: finishedCount,
+		_allSelected: bind(function(mode){
+			return !/^(active|finished)$/.test(mode);
+		}).to(filterMode),
+		_activeSelected: bind(function(mode){
+			return mode == "active";
+		}).to(filterMode),
+		_finishedSelected: bind(function(mode){
+			return mode == "finished";
+		}).to(filterMode),
+		_exists: bind(function(count){
+			return count == 0;
+		}).to(unfilteredCount),
+		_allButton: bind(function(count){
+			return "All (" + count + ")";
+		}).to(count),
+		_activeButton: bind(function(count){
+			return "Active (" + count + ")";
+		}).to(activeCount),
+		_finishedButton: bind(function(count){
+			return "Finished (" + count + ")";
+		}).to(finishedCount),
+		collection: unfiltered,
+		addEntry: function(event, binding, viewModelBinding){
+			var textToAdd = viewModelBinding.get("textToAdd");
+			textToAdd.getValue(function(text){
+				collection.add({title: text, finished: false});
+			});
+			textToAdd.is("");
+		},
+		removeEntry: function(event, binding, viewModelBinding){
+			viewModelBinding.get("id", function(id){
+				collection.remove(id);
+			});
+		},
+		filter: function(event, binding){
+			binding.get("filterMode", function(mode){
+				filterMode.is(mode);
+			});
+		}
+	});
+
+	return viewModel;
+});


### PR DESCRIPTION
This change adds `dbind/forEach` module, as well as `dbind/store/Observable` module.

By importing `dbind/forEach` module (which returns the same object as `dbind/bind`), you can create repeating UI from array:

``` javascript
require(['dbind/forEach'], function(bind){
    var a = ['foo', 'bar'];
    bind(anElement).forEach(a, {
        createChild: function(entry){
            var element = document.createElement("div");
            element.innerText = entry;
            return element;
        }
    });
});
```

If the array implements `observe(function(idx, removals, adds){ ... })` interface upon removals/adds of array elements (splice), the UI created in above way responds to such removals/adds.

`dbind/store/Observable` is based on `dojo/store/Observable`, which adds new third argument to `results.observe(listener, includeObjectUpdates, spliceStyle)`. The new third argument (`spliceStyle`) makes the interface of listener in `observe(function(idx, removals, adds){ ... })` format, instead of `observe(object, removedFrom, insertedInto){ ... })` format.
