### PR TITLE
allow function bindings to bind to null, undefined

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -291,7 +291,7 @@ define([], function(){
 			if(callback){
 				var func = this.func;
 				return this.source.receive(function(value){
-					callback(value.slice ? func.apply(this, value) : func(value));
+					callback(value != null && value.slice ? func.apply(this, value) : func(value));
 				});
 			}
 		},


### PR DESCRIPTION
this stops things from breaking when a function binds to `null` or `undefined`
