### PR TITLE
Add ability to stop listening for changes

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -25,6 +25,17 @@ define([], function(){
 					}
 				});
 			}
+
+			return {
+				remove: function(){
+					for(var i = 0; i < callbacks.length; ++i){
+						if(callback === callbacks[i]){
+							callbacks.splice(i, 1);
+							break;
+						}
+					}
+				}
+			};
 		},
 		getValue: function(callback){
 			if(this.hasOwnProperty("value")){


### PR DESCRIPTION
Sometimes bindings outlive objects that depend on them. In those cases, we need the ability to remove `receive` callbacks associated with those objects.

I updated `Binding.prototype.receive` to return a handle with a `remove` method that can be called to remove the callback. This means that the `get(property, callback)` shorthand is somewhat broken in that `get` cannot return both a binding and a handle for callback removal. Because of this, I removed this shorthand from `bind.js` and the README. While I was in the README, I also corrected mention of `binding.then` to `binding.receive`.

What are your thoughts?

P.S. In getting to know dbind, the shorthand methods were a distraction from seeing the essential simplicity of the API. Perhaps it would be better if there was no shorthand for things like `binding.get(prop).put(value)`.
